### PR TITLE
Add ability to buffer writes to the Log file

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,32 @@ must be a valid vector clock, true is returned on success
 Disables Logging. Log messages will not appear in Log file any longer.
 Note: For the moment, the vector clocks are going to continue being updated.
 
+#### func Flush
+```go
+    func Flush() bool
+```
+
+Writes the log messages stored in the buffer to the Log File.
+Note: Calling Flush when BufferedWrites is disabled is essentially a no-op.
+
+#### func EnableBufferedWrites
+```go
+    func EnableBufferedWrites()
+```
+
+Enables buffered writes to the log file. All the log messages are only written
+to the LogFile via an explicit call to the function Flush.
+Note: Buffered writes are automatically disabled.
+
+#### func DisableBufferedWrites
+```go
+    func DisableBufferedWrites()
+```
+
+Disables buffered writes to the log file. All the log messages from now on
+will be written to the Log file immediately. Writes all the existing
+log messages that haven't been written to Log file yet.
+
 ###   Examples
 
 The following is a basic example of how this library can be used 

--- a/govec/govec.go
+++ b/govec/govec.go
@@ -71,8 +71,13 @@ type GoLog struct {
 
 	logging bool
 
+    buffered bool
+
 	//Logfile name
 	logfile string
+
+    //buffered string
+    output string
 
 	encodingStrategy func(interface{}) ([]byte, error)
 	decodingStrategy func([]byte, interface{}) error
@@ -141,6 +146,8 @@ func InitGoVector(processid string, logfilename string) *GoLog {
 	gv.printonscreen = true //(ShouldYouSeeLoggingOnScreen)
 	gv.debugmode = false    // (Debug)
 	gv.EnableLogging()
+    gv.DisableBufferedWrites()
+    gv.output = ""
 
 	// Use the default encoder/decoder. As of July 2017 this is msgPack.
 	gv.SetEncoderDecoder(gv.DefaultEncoder, gv.DefaultDecoder)
@@ -210,6 +217,8 @@ func InitGoVectorMultipleExecutions(processid string, logfilename string) *GoLog
 	gv.printonscreen = true //(ShouldYouSeeLoggingOnScreen)
 	gv.debugmode = true     // (Debug)
 	gv.EnableLogging()
+    gv.DisableBufferedWrites()
+    gv.output = ""
 
 	// Use the default encoder/decoder. As of July 2017 this is msgPack.
 	gv.SetEncoderDecoder(gv.DefaultEncoder, gv.DefaultDecoder)
@@ -310,6 +319,14 @@ func (gv *GoLog) SetEncoderDecoder(encoder func(interface{}) ([]byte, error), de
 	gv.decodingStrategy = decoder
 }
 
+func (gv *GoLog) EnableBufferedWrites() {
+    gv.buffered = true
+}
+
+func (gv *GoLog) DisableBufferedWrites() {
+    gv.buffered = false
+}
+
 /* Custom encoder function, needed for msgpack interoperability */
 func (d *ClockPayload) EncodeMsgpack(enc *msgpack.Encoder) error {
 
@@ -399,6 +416,22 @@ func (gv *GoLog) DefaultDecoder(buf []byte, payload interface{}) error {
 	return msgpack.Unmarshal(buf, payload)
 }
 
+func (gv *GoLog) Flush() bool {
+    complete := true
+    file, err := os.OpenFile(gv.logfile, os.O_APPEND|os.O_WRONLY, 0600)
+    if err != nil {
+        complete = false
+    }
+    defer file.Close()
+
+    if _, err = file.WriteString(gv.output); err != nil {
+        complete = false
+    }
+
+    gv.output = ""
+    return complete
+}
+
 func (gv *GoLog) LogThis(Message string, ProcessID string, VCString string) bool {
 	complete := true
 	var buffer bytes.Buffer
@@ -410,15 +443,11 @@ func (gv *GoLog) LogThis(Message string, ProcessID string, VCString string) bool
 	buffer.WriteString("\n")
 	output := buffer.String()
 
-	file, err := os.OpenFile(gv.logfile, os.O_APPEND|os.O_WRONLY, 0600)
-	if err != nil {
-		complete = false
-	}
-	defer file.Close()
+    gv.output += output
+    if !gv.buffered {
+        complete = gv.Flush()
+    }
 
-	if _, err = file.WriteString(output); err != nil {
-		complete = false
-	}
 	if gv.printonscreen == true {
 		gv.logger.Println(output)
 	}

--- a/govec/govec.go
+++ b/govec/govec.go
@@ -325,6 +325,7 @@ func (gv *GoLog) EnableBufferedWrites() {
 
 func (gv *GoLog) DisableBufferedWrites() {
     gv.buffered = false
+    gv.Flush()
 }
 
 /* Custom encoder function, needed for msgpack interoperability */

--- a/govec/govec.go
+++ b/govec/govec.go
@@ -71,13 +71,13 @@ type GoLog struct {
 
 	logging bool
 
-    buffered bool
+	buffered bool
 
 	//Logfile name
 	logfile string
 
-    //buffered string
-    output string
+	//buffered string
+	output string
 
 	encodingStrategy func(interface{}) ([]byte, error)
 	decodingStrategy func([]byte, interface{}) error
@@ -146,8 +146,8 @@ func InitGoVector(processid string, logfilename string) *GoLog {
 	gv.printonscreen = true //(ShouldYouSeeLoggingOnScreen)
 	gv.debugmode = false    // (Debug)
 	gv.EnableLogging()
-    gv.DisableBufferedWrites()
-    gv.output = ""
+	gv.output = ""
+	gv.DisableBufferedWrites()
 
 	// Use the default encoder/decoder. As of July 2017 this is msgPack.
 	gv.SetEncoderDecoder(gv.DefaultEncoder, gv.DefaultDecoder)
@@ -217,8 +217,8 @@ func InitGoVectorMultipleExecutions(processid string, logfilename string) *GoLog
 	gv.printonscreen = true //(ShouldYouSeeLoggingOnScreen)
 	gv.debugmode = true     // (Debug)
 	gv.EnableLogging()
-    gv.DisableBufferedWrites()
-    gv.output = ""
+	gv.output = ""
+	gv.DisableBufferedWrites()
 
 	// Use the default encoder/decoder. As of July 2017 this is msgPack.
 	gv.SetEncoderDecoder(gv.DefaultEncoder, gv.DefaultDecoder)
@@ -320,12 +320,14 @@ func (gv *GoLog) SetEncoderDecoder(encoder func(interface{}) ([]byte, error), de
 }
 
 func (gv *GoLog) EnableBufferedWrites() {
-    gv.buffered = true
+	gv.buffered = true
 }
 
 func (gv *GoLog) DisableBufferedWrites() {
-    gv.buffered = false
-    gv.Flush()
+	gv.buffered = false
+	if gv.output != "" {
+		gv.Flush()
+	}
 }
 
 /* Custom encoder function, needed for msgpack interoperability */
@@ -418,19 +420,19 @@ func (gv *GoLog) DefaultDecoder(buf []byte, payload interface{}) error {
 }
 
 func (gv *GoLog) Flush() bool {
-    complete := true
-    file, err := os.OpenFile(gv.logfile, os.O_APPEND|os.O_WRONLY, 0600)
-    if err != nil {
-        complete = false
-    }
-    defer file.Close()
+	complete := true
+	file, err := os.OpenFile(gv.logfile, os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		complete = false
+	}
+	defer file.Close()
 
-    if _, err = file.WriteString(gv.output); err != nil {
-        complete = false
-    }
+	if _, err = file.WriteString(gv.output); err != nil {
+		complete = false
+	}
 
-    gv.output = ""
-    return complete
+	gv.output = ""
+	return complete
 }
 
 func (gv *GoLog) LogThis(Message string, ProcessID string, VCString string) bool {
@@ -444,10 +446,10 @@ func (gv *GoLog) LogThis(Message string, ProcessID string, VCString string) bool
 	buffer.WriteString("\n")
 	output := buffer.String()
 
-    gv.output += output
-    if !gv.buffered {
-        complete = gv.Flush()
-    }
+	gv.output += output
+	if !gv.buffered {
+		complete = gv.Flush()
+	}
 
 	if gv.printonscreen == true {
 		gv.logger.Println(output)


### PR DESCRIPTION
Currently govector Logger doesn't have the ability to buffer writes to the associated Log file and opens/writes/closes to the file at every event. File IO is expensive and this makes the govector Logger pretty much impossible to work with applications/protocols that require low latency (eg: real time game).

This PR adds the ability to enable/disable buffered writes for the logger and passes this control to the user of the Logger.