### PR TITLE
Fix govector.go

### DIFF
--- a/govector.go
+++ b/govector.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 	"runtime/pprof"
 
-	"github.com/DistributedClocks/GoVector/capture"
+	"bitbucket.org/bestchai/dinv/capture"
 )
 
 const (


### PR DESCRIPTION
Since capture is moved to dinv, the import section in govector.go
needs to be changed accordingly. Otherwise "go install" will fail.