### PR TITLE
Fix mutex bug in LogThis

### DIFF
--- a/govec/govec.go
+++ b/govec/govec.go
@@ -188,7 +188,7 @@ func InitGoVector(processid string, logfilename string) *GoLog {
 	file.Close()
 
 	gv.logfile = logname
-	gv.logFunc = gv.LogThis
+	gv.logFunc = gv.logThis
 	//Log it
 	ok := gv.logFunc("Initialization Complete", gv.pid, vc1.ReturnVCString())
 	if ok == false {
@@ -242,7 +242,7 @@ func InitGoVectorMultipleExecutions(processid string, logfilename string) *GoLog
 	logname := logfilename + "-Log.txt"
 	_, err := os.Stat(logname)
 	gv.logfile = logname
-	gv.logFunc = gv.LogThis
+	gv.logFunc = gv.logThis
 	if err == nil {
 		//its exists... deleting old log
 		gv.logger.Println(logname, " exists! ...  Looking for Last Exectution... ")
@@ -438,6 +438,13 @@ func (gv *GoLog) Flush() bool {
 }
 
 func (gv *GoLog) LogThis(Message string, ProcessID string, VCString string) bool {
+	gv.mutex.Lock()
+	ok := gv.logFunc(Message, ProcessID, VCString)
+	gv.mutex.Unlock()
+	return ok
+}
+
+func (gv *GoLog) logThis(Message string, ProcessID string, VCString string) bool {
 	complete := true
 	var buffer bytes.Buffer
 	buffer.WriteString(ProcessID)


### PR DESCRIPTION
Before this change, multiple user threads could call LogThis at the same time on the same logger which could cause inconsistencies in the log file. This is because LogThis, which is exported as part of the API,  doesn't acquire the mutex before writing to file.
This change renames the existing LogThis function to logThis which is the internal function for writing to file. It also adds a new exported version of LogThis, which acquires the mutex before writing to the log file. 
It doesn't change the semantics of the API call to LogThis while guaranteeing consistency of the generated log file.