### PR TITLE
Update example snippet in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The following is a basic example of how this library can be used:
 		Logger.UnpackReceive("Receiving Message", vectorclockmessage, &messagepayload, govec.GetDefaultLogOptions())
 
 		//Log a local event
-		Logger.LogLocalEvent("Example Complete")
+		Logger.LogLocalEvent("Example Complete", govec.GetDefaultLogOptions())
 	}
 ```
 For complete documentation with examples see GoVector's [GoDoc](https://godoc.org/github.com/DistributedClocks/GoVector/govec).

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The following is a basic example of how this library can be used:
 		
 		//Encode message, and update vector clock
 		messagepayload := []byte("samplepayload")
-		vectorclockmessage := Logger.PrepareSend("Sending Message", messagepayload)
+		vectorclockmessage := Logger.PrepareSend("Sending Message", messagepayload, govec.GetDefaultLogOptions())
 		
 		//send message
 		connection.Write(vectorclockmessage)
@@ -67,7 +67,7 @@ The following is a basic example of how this library can be used:
 		//In Receiving Process
 		connection.Read(vectorclockmessage)
 		//Decode message, and update local vector clock with received clock
-		Logger.UnpackReceive("Receiving Message", &messagepayload, vectorclockmessage)
+		Logger.UnpackReceive("Receiving Message", vectorclockmessage, &messagepayload, govec.GetDefaultLogOptions())
 
 		//Log a local event
 		Logger.LogLocalEvent("Example Complete")


### PR DESCRIPTION
In the example snippet available in the README.md file, the parameters passed to `UnpackReceive`  do not seem to match the signature of the function currently available in the API (the order of `buf []byte, unpack interface{}` is inverted). It also looks like for all of `PrepareSend`,`UnpackReceive` and `LogLocalEvent` a GoLogOptions value is required in both calls.