### PR TITLE
Fixed bug in VClock.Compare and added tests for this method

### DIFF
--- a/govec/vclock/vclock.go
+++ b/govec/vclock/vclock.go
@@ -158,9 +158,6 @@ func (vc VClock) Compare(other VClock, cond Condition) bool {
 			if other[id] > vc[id] {
 				switch otherIs {
 				case Equal:
-					if cond&Descendant == 0 {
-						return false
-					}
 					otherIs = Descendant
 					break
 				case Ancestor:
@@ -169,9 +166,6 @@ func (vc VClock) Compare(other VClock, cond Condition) bool {
 			} else if other[id] < vc[id] {
 				switch otherIs {
 				case Equal:
-					if cond&Ancestor == 0 {
-						return false
-					}
 					otherIs = Ancestor
 					break
 				case Descendant:
@@ -185,6 +179,11 @@ func (vc VClock) Compare(other VClock, cond Condition) bool {
 				return cond&Concurrent != 0
 			}
 		}
+	}
+
+	//Equal clocks are concurrent
+	if otherIs == Equal && cond == Concurrent {
+		cond = Equal
 	}
 	return cond&otherIs != 0
 }

--- a/govec/vclock/vclock_test.go
+++ b/govec/vclock/vclock_test.go
@@ -88,12 +88,195 @@ func TestCompareAndMerge(t *testing.T) {
 		failComparison(t, "Clocks not defined as Descendant: n1 = %s | n2 = %s", n1, n3)
 	} else if !n2.Compare(n3, Descendant) {
 		failComparison(t, "Clocks not defined as Descendant: n1 = %s | n2 = %s", n2, n3)
+	} else if !n1.Compare(n2, Concurrent) {
+		failComparison(t, "Clocks not defined as concurrent: n1 = %s | n2 = %s", n1, n2)
 	}
-	/*
-		//TODO cfung: This test fails, I think it is a bug
-		else if !n1.Compare(n2, Concurrent) {
-		failComparison(t,"Clocks not defined as concurrent: n1 = %s | n2 = %s",n1,n2)
-	}*/
+}
+
+func TestCompareDiffLengthsNonConcurrent(t *testing.T) {
+	n1 := New()
+	n2 := New()
+
+	n1.Set("a", 1)
+	n2.Set("a", 1)
+	n2.Set("b", 1)
+
+	if n1.Compare(n2, Equal) {
+		failComparison(t, "Clocks are defined as Equal: n1 = %s | n2 = %s", n1, n2)
+	} else if n1.Compare(n2, Ancestor) {
+		failComparison(t, "Clocks are defined as Ancestor: n1 = %s | n2 = %s", n1, n2)
+	} else if !n1.Compare(n2, Descendant) {
+		failComparison(t, "Clocks not defined as Descendant: n1 = %s | n2 = %s", n1, n2)
+	} else if n1.Compare(n2, Concurrent) {
+		failComparison(t, "Clocks are defined as Concurrent: n1 = %s | n2 = %s", n1, n2)
+	}
+
+	if n2.Compare(n1, Equal) {
+		failComparison(t, "Clocks are defined as Equal: n1 = %s | n2 = %s", n2, n1)
+	} else if !n2.Compare(n1, Ancestor) {
+		failComparison(t, "Clocks not defined as Ancestor: n1 = %s | n2 = %s", n2, n1)
+	} else if n2.Compare(n1, Descendant) {
+		failComparison(t, "Clocks are defined as Descendant: n1 = %s | n2 = %s", n2, n1)
+	} else if n2.Compare(n1, Concurrent) {
+		failComparison(t, "Clocks are defined as Concurrent: n1 = %s | n2 = %s", n2, n1)
+	}
+}
+
+func TestCompareDiffLengthsConcurrent(t *testing.T) {
+	n1 := New()
+	n2 := New()
+
+	n1.Set("a", 2)
+	n2.Set("a", 1)
+	n2.Set("b", 1)
+
+	if n1.Compare(n2, Equal) {
+		failComparison(t, "Clocks are defined as Equal: n1 = %s | n2 = %s", n1, n2)
+	} else if n1.Compare(n2, Ancestor) {
+		failComparison(t, "Clocks are defined as Ancestor: n1 = %s | n2 = %s", n1, n2)
+	} else if n1.Compare(n2, Descendant) {
+		failComparison(t, "Clocks are defined as Descendant: n1 = %s | n2 = %s", n1, n2)
+	} else if !n1.Compare(n2, Concurrent) {
+		failComparison(t, "Clocks not defined as Concurrent: n1 = %s | n2 = %s", n1, n2)
+	}
+
+	if n2.Compare(n1, Equal) {
+		failComparison(t, "Clocks are defined as Equal: n1 = %s | n2 = %s", n2, n1)
+	} else if n2.Compare(n1, Ancestor) {
+		failComparison(t, "Clocks are defined as Ancestor: n1 = %s | n2 = %s", n2, n1)
+	} else if n2.Compare(n1, Descendant) {
+		failComparison(t, "Clocks are defined as Descendant: n1 = %s | n2 = %s", n2, n1)
+	} else if !n2.Compare(n1, Concurrent) {
+		failComparison(t, "Clocks not defined as Concurrent: n1 = %s | n2 = %s", n2, n1)
+	}
+}
+
+func TestCompareIdenticalClocks(t *testing.T) {
+	n1 := New()
+	n2 := New()
+
+	n1.Set("a", 1)
+	n1.Set("b", 2)
+	n1.Set("c", 3)
+	n2.Set("a", 1)
+	n2.Set("b", 2)
+	n2.Set("c", 3)
+
+	if !n1.Compare(n2, Equal) {
+		failComparison(t, "Clocks not defined as Equal: n1 = %s | n2 = %s", n1, n2)
+	} else if n1.Compare(n2, Ancestor) {
+		failComparison(t, "Clocks are defined as Ancestor: n1 = %s | n2 = %s", n1, n2)
+	} else if n1.Compare(n2, Descendant) {
+		failComparison(t, "Clocks are defined as Descendant: n1 = %s | n2 = %s", n1, n2)
+	} else if !n1.Compare(n2, Concurrent) {
+		failComparison(t, "Clocks not defined as Concurrent: n1 = %s | n2 = %s", n1, n2)
+	}
+
+	if !n2.Compare(n1, Equal) {
+		failComparison(t, "Clocks not defined as Equal: n1 = %s | n2 = %s", n2, n1)
+	} else if n2.Compare(n1, Ancestor) {
+		failComparison(t, "Clocks are defined as Ancestor: n1 = %s | n2 = %s", n2, n1)
+	} else if n2.Compare(n1, Descendant) {
+		failComparison(t, "Clocks are defined as Descendant: n1 = %s | n2 = %s", n2, n1)
+	} else if !n2.Compare(n1, Concurrent) {
+		failComparison(t, "Clocks not defined as Concurrent: n1 = %s | n2 = %s", n2, n1)
+	}
+}
+
+func TestCompareSameLengthConcurrent(t *testing.T) {
+	n1 := New()
+	n2 := New()
+
+	n1.Set("a", 1)
+	n1.Set("b", 2)
+	n1.Set("c", 3)
+	n2.Set("a", 3)
+	n2.Set("b", 2)
+	n2.Set("c", 1)
+
+	if n1.Compare(n2, Equal) {
+		failComparison(t, "Clocks are defined as Equal: n1 = %s | n2 = %s", n1, n2)
+	} else if n1.Compare(n2, Ancestor) {
+		failComparison(t, "Clocks are defined as Ancestor: n1 = %s | n2 = %s", n1, n2)
+	} else if n1.Compare(n2, Descendant) {
+		failComparison(t, "Clocks are defined as Descendant: n1 = %s | n2 = %s", n1, n2)
+	} else if !n1.Compare(n2, Concurrent) {
+		failComparison(t, "Clocks not defined as Concurrent: n1 = %s | n2 = %s", n1, n2)
+	}
+
+	if n2.Compare(n1, Equal) {
+		failComparison(t, "Clocks are defined as Equal: n1 = %s | n2 = %s", n2, n1)
+	} else if n2.Compare(n1, Ancestor) {
+		failComparison(t, "Clocks are defined as Ancestor: n1 = %s | n2 = %s", n2, n1)
+	} else if n2.Compare(n1, Descendant) {
+		failComparison(t, "Clocks are defined as Descendant: n1 = %s | n2 = %s", n2, n1)
+	} else if !n2.Compare(n1, Concurrent) {
+		failComparison(t, "Clocks not defined as Concurrent: n1 = %s | n2 = %s", n2, n1)
+	}
+}
+
+func TestCompareSameLengthNonConcurrent(t *testing.T) {
+	n1 := New()
+	n2 := New()
+
+	n1.Set("a", 1)
+	n1.Set("b", 2)
+	n1.Set("c", 3)
+	n2.Set("a", 2)
+	n2.Set("b", 2)
+	n2.Set("c", 3)
+
+	if n1.Compare(n2, Equal) {
+		failComparison(t, "Clocks are defined as Equal: n1 = %s | n2 = %s", n1, n2)
+	} else if n1.Compare(n2, Ancestor) {
+		failComparison(t, "Clocks are defined as Ancestor: n1 = %s | n2 = %s", n1, n2)
+	} else if !n1.Compare(n2, Descendant) {
+		failComparison(t, "Clocks not defined as Descendant: n1 = %s | n2 = %s", n1, n2)
+	} else if n1.Compare(n2, Concurrent) {
+		failComparison(t, "Clocks are defined as Concurrent: n1 = %s | n2 = %s", n1, n2)
+	}
+
+	if n2.Compare(n1, Equal) {
+		failComparison(t, "Clocks are defined as Equal: n1 = %s | n2 = %s", n2, n1)
+	} else if !n2.Compare(n1, Ancestor) {
+		failComparison(t, "Clocks not defined as Ancestor: n1 = %s | n2 = %s", n2, n1)
+	} else if n2.Compare(n1, Descendant) {
+		failComparison(t, "Clocks are defined as Descendant: n1 = %s | n2 = %s", n2, n1)
+	} else if n2.Compare(n1, Concurrent) {
+		failComparison(t, "Clocks are defined as Concurrent: n1 = %s | n2 = %s", n2, n1)
+	}
+}
+
+func TestCompareNonIdenticalNames(t *testing.T) {
+	n1 := New()
+	n2 := New()
+
+	n1.Set("a", 1)
+	n1.Set("b", 2)
+	n1.Set("c", 3)
+	n2.Set("a", 1)
+	n2.Set("b", 2)
+	n2.Set("d", 3)
+
+	if n1.Compare(n2, Equal) {
+		failComparison(t, "Clocks are defined as Equal: n1 = %s | n2 = %s", n1, n2)
+	} else if n1.Compare(n2, Ancestor) {
+		failComparison(t, "Clocks are defined as Ancestor: n1 = %s | n2 = %s", n1, n2)
+	} else if n1.Compare(n2, Descendant) {
+		failComparison(t, "Clocks are defined as Descendant: n1 = %s | n2 = %s", n1, n2)
+	} else if !n1.Compare(n2, Concurrent) {
+		failComparison(t, "Clocks not defined as Concurrent: n1 = %s | n2 = %s", n1, n2)
+	}
+
+	if n2.Compare(n1, Equal) {
+		failComparison(t, "Clocks are defined as Equal: n1 = %s | n2 = %s", n2, n1)
+	} else if n2.Compare(n1, Ancestor) {
+		failComparison(t, "Clocks are defined as Ancestor: n1 = %s | n2 = %s", n2, n1)
+	} else if n2.Compare(n1, Descendant) {
+		failComparison(t, "Clocks are defined as Descendant: n1 = %s | n2 = %s", n2, n1)
+	} else if !n2.Compare(n1, Concurrent) {
+		failComparison(t, "Clocks not defined as Concurrent: n1 = %s | n2 = %s", n2, n1)
+	}
 }
 
 func failComparison(t *testing.T, failMessage string, clock1, clock2 VClock) {


### PR DESCRIPTION
As attributed to in the TODO comment by cfung on lines 92-96 of vclock_test.go, there was indeed a bug in the VClock.Compare method. The method as is would not detect all concurrent clocks, as it was premature to return false in lines 161-163 and 172-174 of the original code. 

I corrected the method, uncommented the test commented out by cfung and added several new tests to vclock_test.go to comprehensively check the VClock.Compare method. All tests pass.