### PR TITLE
Make ReturnVCString Deterministic

### DIFF
--- a/govec/vclock/vclock.go
+++ b/govec/vclock/vclock.go
@@ -5,6 +5,7 @@ import (
 	"encoding/gob"
 	"fmt"
 	"log"
+	"sort"
 )
 
 // Condition constants define how to compare a vector clock against another,
@@ -120,6 +121,8 @@ func (vc VClock) ReturnVCString() string {
 		ids[i] = id
 		i++
 	}
+
+	sort.Strings(ids)
 
 	var buffer bytes.Buffer
 	buffer.WriteString("{")

--- a/govec/vclock/vclock_test.go
+++ b/govec/vclock/vclock_test.go
@@ -301,3 +301,23 @@ func TestEncodeDecode(t *testing.T) {
 		t.Fatalf("decoded not the same as encoded enc = %s | dec = %s", nString, dString)
 	}
 }
+
+func TestVCString(t *testing.T)  {
+	n := New()
+
+	n.Set("a", 1)
+	n.Set("b", 1)
+	n.Set("c", 1)
+	n.Set("d", 1)
+	n.Set("e", 1)
+	n.Set("f", 1)
+	n.Set("g", 1)
+	n.Set("h", 1)
+
+	expected := "{\"a\":1, \"b\":1, \"c\":1, \"d\":1, \"e\":1, \"f\":1, \"g\":1, \"h\":1}"
+	nString := n.ReturnVCString()
+
+	if nString != expected {
+		t.Fatalf("VC string %s not the same as expected %s", nString, expected )
+	}
+}


### PR DESCRIPTION
Currently when getting the string representation for a vector clock, you will get a non-deterministic order of keys and values. The reason is that ranging over a map in Go gives you its keys in a random order. Nevertheless, the current implementation of `ReturnVCString` in the `vclock` package relies on ranging over the keys to sort the output (note that the comment is from the original code):

```go
//sort
ids := make([]string, len(vc))
i := 0
for id := range vc {
	ids[i] = id
	i++
}
```

So I'm assuming that non-deterministic output is a bug and not intentional.  
For some use-cases (notably: my use-case 🙂), this can be problematic. My proposal is to add an additional `sort.Strings(ids)` step before using the array of keys so that `iff v1 == v2 => v1.ReturnVCString() == v2.ReturnVCString()`. This should prevent any further surprises.

There is a performance overhead but I find it negligible. For a vector clock with 100 entries (quite large):

```sh
goos: darwin
goarch: amd64
pkg: github.com/DistributedClocks/GoVector/govec/vclock
cpu: Intel(R) Core(TM) i5-8210Y CPU @ 1.60GHz
BenchmarkVCString-4         	   28614	     40648 ns/op
BenchmarkVCStringSorted-4   	   20901	     57339 ns/op
PASS
ok  	github.com/DistributedClocks/GoVector/govec/vclock	3.386s
```

(This benchmark is not included in this PR, just illustrative.)  
0.017ms is acceptable, although that difference is grows or shrinks with the size of the clock.