### PR TITLE
Update command line for installing govector

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Once you set up your environment, GoVector can be installed with the go
 tool command:
 
 ```
-$ go get -u github.com/DistributedClocks/GoVector
+$ go install github.com/DistributedClocks/GoVector
 ```
 
 ### Usage


### PR DESCRIPTION
Currently the command described in the README for installing GoVector uses `go get -u` which is no longer supported outside a module for newer versions of Go. This PR updates this the command to `go install` which is the correct command for installing tools built with go.