### PR TITLE
dont use DecodeMulti

### DIFF
--- a/govec/govec.go
+++ b/govec/govec.go
@@ -209,11 +209,7 @@ func (d *VClockPayload) DecodeMsgpack(dec *msgpack.Decoder) error {
 		}
 		vcMap[key] = value
 	}
-	err = dec.DecodeMulti(&d.Pid, &d.Payload, &d.VcMap)
 	d.VcMap = vcMap
-	if err != nil {
-		return err
-	}
 
 	return nil
 }


### PR DESCRIPTION
Hello! I noticed that when `logToTerminal` is true, `EOF` errors are printed due to line 578. For example, with `go test -v`, output includes

```
=== RUN   TestSendAndUnpackInt
[GoVector]:govec.go:328: TestLogFile-Log.txt exists! ... Deleting 
[GoVector]:govec.go:578: EOF
```

Printing each field of `e` when this occurs, the output shows that `e.Pid` is not set. This is due to `dec.DecodeMulti` being called after the `VClockPayload` has already been decoded. This leaves no data for the subsequent decode into `d.Pid`, hence the `EOF`.

If desired, I can also add/modify a test like this in `govec_test.go`:

```
logToTerminal = true
var buf bytes.Buffer
logger := log.New(&buf, "", 0)
gv.logger = logger
gv.UnpackReceive("TestMessage", packed, &response, opts)
AssertEquals(t, false, strings.Contains(buf.String(), "EOF"), "Error when decoding")
```